### PR TITLE
Adding decodeBytestrings / decodeBytestringsEither, tests/CI and bit of a clean up.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
 # NB: don't set `language: haskell` here
 
+cache:
+  directories:
+  - $HOME/.ghc
+  - $HOME/.cabal
+  - $HOME/.stack
+
 env:
- - CABALVER=1.22.5.0 GHCVER=7.10.3 GHCOPTS=""
+ - CABALVER=1.22 GHCVER=7.10.3 GHCOPTS=""
 
 # Note: the distinction between `before_install` and `install` is not important.
 before_install:
@@ -18,5 +24,5 @@ install:
 script:
  - cabal-$CABALVER configure --enable-tests -v2  # -v2 provides useful information for debugging
  - cabal-$CABALVER build  --ghc-options=$GHCOPTS # this builds all libraries and executables (including tests/benchmarks)
-   # - cabal-$CABALVER test
+ - cabal-$CABALVER test --show-details=always
    # - cabal-$CABALVER check

--- a/bin/yaml-union.hs
+++ b/bin/yaml-union.hs
@@ -1,6 +1,5 @@
 module Main where
 import Options.Applicative
-import Data.Monoid
 import qualified Data.Yaml as Y
 import Data.Yaml.Pretty
 import Data.Yaml.Union
@@ -22,16 +21,16 @@ cfg =
 
 union :: Options -> IO ()
 union (Options{files = fs, dashes = dsh}) =
-  do s <- decodeFilesEither fs
+  do sOrErr <- decodeFilesEither fs
      let yaml =
-           case s of
+           case sOrErr of
              Left s -> error $ "Yaml-File parsing failed " ++ s
              Right x ->  x :: Y.Object
      let ymlStr = encodePretty defConfig yaml
-     let str = if dsh
+     let s = if dsh
                   then B.unlines [ B.pack "---",  ymlStr, B.pack "..."]
                   else ymlStr
-     B.putStrLn str
+     B.putStrLn s
 
 main :: IO ()
 main = execParser opts >>= union

--- a/bin/yaml-union.hs
+++ b/bin/yaml-union.hs
@@ -1,5 +1,6 @@
 module Main where
 import Options.Applicative
+import Data.Monoid
 import qualified Data.Yaml as Y
 import Data.Yaml.Pretty
 import Data.Yaml.Union

--- a/spec/Spec.hs
+++ b/spec/Spec.hs
@@ -1,0 +1,2 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}
+

--- a/spec/UnionSpec.hs
+++ b/spec/UnionSpec.hs
@@ -1,0 +1,85 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module UnionSpec where
+
+import           Data.Char
+import           Data.HashMap.Strict (HashMap)
+import qualified Data.HashMap.Strict as HashMap
+import           Data.Scientific
+import           Data.Text (Text)
+import qualified Data.Text as Text
+import           Data.Vector (Vector)
+import qualified Data.Vector as Vec
+import           Data.Yaml
+import           Data.Yaml.Union
+import           Test.Hspec
+import           Test.QuickCheck
+-- import           Test.QuickCheck.Instances ()
+
+-- Null gets omitted in encoding so we are not including it here
+instance Arbitrary Value where
+  arbitrary =
+    oneof
+      [ Object <$>
+        resize
+          5
+          arbitrary
+      , Array <$> resize 5 arbitrary
+      , String <$> arbitrary
+      , Number <$> arbitrary
+      , Bool <$> arbitrary
+      ]
+
+-- hash maps with keys that are not empty and contain ASCII characters only
+instance (Arbitrary v) =>
+         Arbitrary (HashMap Text v) where
+  arbitrary =
+    HashMap.fromList <$>
+    (arbitrary `suchThat`
+     (\t ->
+        all ((> 0) . Text.length . fst) t && all (Text.all isAsciiLower . fst) t))
+
+instance Arbitrary a => Arbitrary (Vector a) where
+  arbitrary = Vec.fromList <$> arbitrary
+
+instance Arbitrary Text where
+  arbitrary = Text.pack <$> arbitrary
+
+instance Arbitrary Scientific where
+    arbitrary = do
+        c <- arbitrary
+        e <- arbitrary
+        return $ scientific c e
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec =
+  describe "Union" $ do
+    it "with itself == id" $
+      property $ \(x :: Object) ->
+        decodeBytestrings [encode x, encode x] `shouldBe` Just x
+    it "preserves keys" $
+      property $ \(x :: Object, y :: Object) ->
+        collectKeys <$>
+        (decodeBytestrings [encode x, encode y] :: Maybe Value) `shouldBe`
+        Just (collectKeys (Object x) ++ collectKeys (Object y))
+    it "decompose" $
+      property $ \(x :: Object) ->
+        (decodeBytestrings $ map (encode . Object) $ decompose x :: Maybe Value) `shouldBe`
+        Just (Object x)
+
+collectKeys :: Value -> [Text]
+collectKeys (Object o) =
+  HashMap.keys o ++ concatMap collectKeys (HashMap.elems o)
+collectKeys _ = []
+
+decompose :: HashMap Text v -> [HashMap Text v]
+decompose m
+  | HashMap.size m == 0 = []
+  | otherwise =
+    let t = HashMap.fromList $ tail $ HashMap.toList m
+    in m : decompose t

--- a/src/Data/Yaml/Dirs.hs
+++ b/src/Data/Yaml/Dirs.hs
@@ -2,7 +2,7 @@
 module Data.Yaml.Dirs (mergeDirs, decodeFiles) where
 
 import qualified Data.Yaml as Yaml
-import           Data.Maybe (catMaybes, fromJust)
+import           Data.Maybe (fromJust)
 import           System.FilePath
 import qualified Data.HashMap.Strict as M
 import qualified Data.Text as T
@@ -10,7 +10,7 @@ import qualified Data.Vector as V
 import           Data.List (sort)
 
 mergeDirs :: FilePath -> FilePath -> IO Yaml.Object
-mergeDirs d f = undefined
+mergeDirs _d _f = undefined
 
 decodeFiles :: Bool -> [FilePath] -> IO Yaml.Value
 decodeFiles sortKeysIncreasing fs =

--- a/src/Data/Yaml/Union.hs
+++ b/src/Data/Yaml/Union.hs
@@ -6,9 +6,10 @@ module Data.Yaml.Union
   ) where
 
 import           Data.ByteString (ByteString)
+import qualified Data.ByteString  as Bytes
 import           Data.Foldable
 import qualified Data.HashMap.Strict as M
-import           Data.Maybe (catMaybes,mapMaybe)
+import           Data.Maybe (mapMaybe)
 import           Data.Vector (Vector)
 import qualified Data.Vector as Vec
 import           Data.Yaml
@@ -28,16 +29,11 @@ decodeBytestringsEither =
 
 -- | Decode multiple YAML-files and override fields recursively
 decodeFiles :: FromJSON a => [FilePath] -> IO (Maybe a)
-decodeFiles fs =  fmap (parseMaybe parseJSON . Object) (readFiles fs)
+decodeFiles fs =  decodeBytestrings <$> mapM Bytes.readFile fs
 
 -- | Decode multiple YAML-files and override fields recursively
 decodeFilesEither :: FromJSON a => [FilePath] -> IO (Either String a)
-decodeFilesEither fs = fmap (parseEither parseJSON . Object) (readFiles fs)
-
-readFiles :: [FilePath] -> IO Object
-readFiles fs =
-  do cfgs <- mapM decodeFile fs
-     return . unions . catMaybes $ cfgs
+decodeFilesEither fs = decodeBytestringsEither <$> mapM Bytes.readFile fs
 
 unions :: [Object] -> Object
 unions = foldl' union M.empty
@@ -64,7 +60,7 @@ vecDeleteBy eq x ys
   | Vec.length ys == 0 = ys
   | otherwise =
     if x `eq` Vec.head ys
-      then (Vec.tail ys)
+      then Vec.tail ys
       else Vec.head ys `Vec.cons` vecDeleteBy eq x (Vec.tail ys)
 
 vecNubBy :: (a -> a -> Bool) -> Vector a -> Vector a

--- a/src/Data/Yaml/Union.hs
+++ b/src/Data/Yaml/Union.hs
@@ -8,6 +8,8 @@ module Data.Yaml.Union
 import           Data.ByteString (ByteString)
 import qualified Data.HashMap.Strict as M
 import           Data.Maybe (catMaybes,mapMaybe)
+import           Data.Vector (Vector)
+import qualified Data.Vector as Vec
 import           Data.Yaml
 
 decodeBytestrings
@@ -42,5 +44,29 @@ union = M.unionWith dispatch
 
 dispatch :: Value -> Value -> Value
 dispatch (Object v1) (Object v2) = Object (v1 `union` v2)
---dispatch (Array v1) (Array v2) = undefined
+dispatch (Array v1) (Array v2) = Array $ vecUnion v1 v2
 dispatch _ x   = x
+
+vecUnion
+  :: Eq a
+  => Vector a -> Vector a -> Vector a
+vecUnion = vecUnionBy (==)
+
+vecUnionBy :: (a -> a -> Bool) -> Vector a -> Vector a -> Vector a
+vecUnionBy eq xs ys =
+  (Vec.++) xs (foldl (flip (vecDeleteBy eq)) (vecNubBy eq ys) xs)
+
+vecDeleteBy :: (a -> a -> Bool) -> a -> Vector a -> Vector a
+vecDeleteBy eq x ys
+  | Vec.length ys == 0 = ys
+  | otherwise =
+    if x `eq` Vec.head ys
+      then (Vec.tail ys)
+      else Vec.head ys `Vec.cons` vecDeleteBy eq x (Vec.tail ys)
+
+vecNubBy :: (a -> a -> Bool) -> Vector a -> Vector a
+vecNubBy eq vec
+  | Vec.length vec == 0 = vec
+  | otherwise =
+    Vec.head vec `Vec.cons`
+    vecNubBy eq (Vec.filter (not . eq (Vec.head vec)) (Vec.tail vec))

--- a/src/Data/Yaml/Union.hs
+++ b/src/Data/Yaml/Union.hs
@@ -1,7 +1,25 @@
-module Data.Yaml.Union (decodeFiles, decodeFilesEither) where
+module Data.Yaml.Union
+  ( decodeBytestrings
+  , decodeBytestringsEither
+  , decodeFiles
+  , decodeFilesEither
+  ) where
+
+import           Data.ByteString (ByteString)
 import qualified Data.HashMap.Strict as M
-import           Data.Maybe (catMaybes)
+import           Data.Maybe (catMaybes,mapMaybe)
 import           Data.Yaml
+
+decodeBytestrings
+  :: FromJSON a
+  => [ByteString] -> Maybe a
+decodeBytestrings = parseMaybe parseJSON . Object . unions . mapMaybe decode
+
+decodeBytestringsEither
+  :: FromJSON a
+  => [ByteString] -> Either String a
+decodeBytestringsEither =
+  parseEither parseJSON . Object . unions . mapMaybe decode
 
 -- | Decode multiple YAML-files and override recurisvley field
 decodeFiles :: FromJSON a => [FilePath] -> IO (Maybe a)

--- a/src/Data/Yaml/Union.hs
+++ b/src/Data/Yaml/Union.hs
@@ -13,22 +13,24 @@ import           Data.Vector (Vector)
 import qualified Data.Vector as Vec
 import           Data.Yaml
 
+-- | Decode multiple YAML strings and override fields recursively
 decodeBytestrings
   :: FromJSON a
   => [ByteString] -> Maybe a
 decodeBytestrings = parseMaybe parseJSON . Object . unions . mapMaybe decode
 
+-- | Decode multiple YAML strings and override fields recursively
 decodeBytestringsEither
   :: FromJSON a
   => [ByteString] -> Either String a
 decodeBytestringsEither =
   parseEither parseJSON . Object . unions . mapMaybe decode
 
--- | Decode multiple YAML-files and override recurisvley field
+-- | Decode multiple YAML-files and override fields recursively
 decodeFiles :: FromJSON a => [FilePath] -> IO (Maybe a)
 decodeFiles fs =  fmap (parseMaybe parseJSON . Object) (readFiles fs)
 
--- | Decode multiple YAML-files and override recurisvley field
+-- | Decode multiple YAML-files and override fields recursively
 decodeFilesEither :: FromJSON a => [FilePath] -> IO (Either String a)
 decodeFilesEither fs = fmap (parseEither parseJSON . Object) (readFiles fs)
 

--- a/src/Data/Yaml/Union.hs
+++ b/src/Data/Yaml/Union.hs
@@ -6,6 +6,7 @@ module Data.Yaml.Union
   ) where
 
 import           Data.ByteString (ByteString)
+import           Data.Foldable
 import qualified Data.HashMap.Strict as M
 import           Data.Maybe (catMaybes,mapMaybe)
 import           Data.Vector (Vector)
@@ -37,7 +38,7 @@ readFiles fs =
      return . unions . catMaybes $ cfgs
 
 unions :: [Object] -> Object
-unions = foldl1 union
+unions = foldl' union M.empty
 
 union ::  Object ->  Object -> Object
 union = M.unionWith dispatch

--- a/yaml-union.cabal
+++ b/yaml-union.cabal
@@ -33,12 +33,22 @@ library
   hs-source-dirs:      src
   default-language:    Haskell2010
 
--- test-suite test
---   type:       exitcode-stdio-1.0
---   main-is:    Example.hs
---   hs-source-dirs: tests
---   build-depends: base
---   default-language:    Haskell2010
+test-suite test
+  type:       exitcode-stdio-1.0
+  main-is:    Spec.hs
+  other-modules: UnionSpec
+  hs-source-dirs: spec
+  build-depends: QuickCheck
+               , base
+               , hspec
+               , quickcheck-instances
+               , scientific
+               , text
+               , unordered-containers
+               , vector
+               , yaml
+               , yaml-union
+  default-language:    Haskell2010
 
 executable yaml-union 
   build-depends: base

--- a/yaml-union.cabal
+++ b/yaml-union.cabal
@@ -23,6 +23,7 @@ library
   -- other-modules:       
   -- other-extensions:    
   build-depends:       base >= 4 && < 5
+                     , bytestring
                      , unordered-containers
                      , yaml
                      , filepath

--- a/yaml-union.cabal
+++ b/yaml-union.cabal
@@ -33,6 +33,7 @@ library
 
   hs-source-dirs:      src
   default-language:    Haskell2010
+  ghc-options: -Wall
 
 test-suite test
   type:       exitcode-stdio-1.0
@@ -50,6 +51,7 @@ test-suite test
                , yaml >=0.8.20 && <0.9
                , yaml-union >=0.0.1 && <0.1
   default-language:    Haskell2010
+  ghc-options: -Wall
 
 executable yaml-union 
   build-depends:  base >=4.0 && < 5
@@ -61,6 +63,7 @@ executable yaml-union
   hs-source-dirs:  bin
   Main-Is:         yaml-union.hs
   default-language:    Haskell2010
+  ghc-options: -Wall
 
 executable yaml-concat
   build-depends:  base >=4.0 && < 5
@@ -71,3 +74,4 @@ executable yaml-concat
   hs-source-dirs:  bin
   Main-Is:         yaml-union.hs
   default-language:    Haskell2010
+  ghc-options: -Wall

--- a/yaml-union.cabal
+++ b/yaml-union.cabal
@@ -22,14 +22,15 @@ library
                      , Data.Yaml.Dirs
   -- other-modules:       
   -- other-extensions:    
-  build-depends:       base >= 4 && < 5
-                     , bytestring
-                     , unordered-containers
-                     , yaml
-                     , filepath
-                     , aeson
-                     , text
-                     , vector
+  build-depends: base >= 4 && < 5
+               , bytestring >=0.10.8.1 && <0.11
+               , unordered-containers >=0.2.7.1 && <0.3
+               , yaml >=0.8.20 && <0.9
+               , filepath >=1.4.1.0 && <1.5
+               , aeson >=0.11.2.1 && <0.12
+               , text >=1.2.2.1 && <1.3
+               , vector >=0.11.0.0 && <0.12
+
   hs-source-dirs:      src
   default-language:    Haskell2010
 
@@ -38,34 +39,35 @@ test-suite test
   main-is:    Spec.hs
   other-modules: UnionSpec
   hs-source-dirs: spec
-  build-depends: QuickCheck
-               , base
-               , hspec
-               , quickcheck-instances
-               , scientific
-               , text
-               , unordered-containers
-               , vector
-               , yaml
-               , yaml-union
+  build-depends: QuickCheck >=2.8.2 && <2.9
+               , base >=4.0 && < 5
+               , hspec >=2.2.4 && <2.3
+               , quickcheck-instances >=0.3.12 && <0.4
+               , scientific >=0.3.4.9 && <0.4
+               , text >=1.2.2.1 && <1.3
+               , unordered-containers >=0.2.7.1 && <0.3
+               , vector >=0.11.0.0 && <0.12
+               , yaml >=0.8.20 && <0.9
+               , yaml-union >=0.0.1 && <0.1
   default-language:    Haskell2010
 
 executable yaml-union 
-  build-depends: base
-               , bytestring
-               , optparse-applicative
-               , yaml
-               , yaml-union
+  build-depends:  base >=4.0 && < 5
+                , bytestring >=0.10.8.1 && <0.11
+                , optparse-applicative >=0.12.1.0 && <0.13
+                , yaml >=0.8.20 && <0.9
+                , yaml-union >=0.0.1 && <0.1
+
   hs-source-dirs:  bin
   Main-Is:         yaml-union.hs
   default-language:    Haskell2010
 
 executable yaml-concat
-  build-depends: base
-               , bytestring
-               , optparse-applicative
-               , yaml
-               , yaml-union
+  build-depends:  base >=4.0 && < 5
+                , bytestring >=0.10.8.1 && <0.11
+                , optparse-applicative >=0.12.1.0 && <0.13
+                , yaml >=0.8.20 && <0.9
+                , yaml-union >=0.0.1 && <0.1
   hs-source-dirs:  bin
   Main-Is:         yaml-union.hs
   default-language:    Haskell2010


### PR DESCRIPTION
Hi there,

I found myself wanting to use this library however with a need for merging multiple YAML documents represented as a list of `ByteString`s, rather than supplying a list of files to be read.
In the process I added ability to merge `Array`s using `nub` equivalent for `Vector`, few (hopefully useful) tests that also run on Travis, and cleaned up some compiler warnings.
I'm quite new at this but submitting my changes in case you find them useful and wish to integrate them. I believe this would be backwards incompatible change as new symbols would be exported from `Data.Yaml.Union`
Thank you!